### PR TITLE
Fix typo in exclude word

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ USAGE:
 FLAGS:
         --blame                     Look if I changed the same files in the past (SLOW)
     -d, --debug                     Add debug information
-        --exclude-tests-success     Exclide pull requests with tests successful
+        --exclude-tests-success     Exclude pull requests with tests successful
     -h, --help                      Prints help information
         --include-mine              Include my pull requests
         --include-reviewed-by-me    Include pull requests I have reviewed

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -64,7 +64,7 @@ pub struct Pr {
         help = "Include pull requests with no tests executed (usually because of conflicts)"
     )]
     pub include_tests_none: bool,
-    #[structopt(long, help = "Exclide pull requests with tests successful")]
+    #[structopt(long, help = "Exclude pull requests with tests successful")]
     pub exclude_tests_success: bool,
     #[structopt(long, help = "Select tests via regexp. The others are ignored")]
     pub tests_regex: Option<String>,


### PR DESCRIPTION
It looks like a typo.
I guess, it should be `exclude` instead of `exclide`.