### PR TITLE
v1.0.12 - Optimize tokio features and upgrade crates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
     branches: "*"
+  pull_request:
 
 env:
   CARGO_TERM_COLOR: always

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v1.0.12
+
+- Optimize tokio features from "full" to ["rt-multi-thread", "macros"] for faster compilation.
+- Remove caret (^) version constraints from dependencies.
+- Remove signal-hook-registry dependency (unused).
+- Upgrade crates.
+
 ## v1.0.11
 
 - Remove OpenSSL dependency by switching to rustls-tls.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "ateam"
-version = "1.0.11"
+version = "1.0.12"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1333,16 +1333,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
-dependencies = [
- "errno",
- "libc",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1508,9 +1498,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
- "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ateam"
-version = "1.0.11"
+version = "1.0.12"
 authors = ["Andrea Frigido"]
 license = "MIT"
 description = "The tool that helps optimize the code review process."
@@ -31,21 +31,21 @@ debug = true
 split-debuginfo = "packed"
 
 [dependencies]
-anyhow = "^1.0.102"
-graphql_client = "^0.14"
-serde = "^1.0"
-serde_json = "^1.0"
-reqwest = { version = "^0.12", default-features = false, features = ["json", "rustls-tls"] }
-terminal_size = "^0.4"
-comfy-table = "^7.2.2"
-dotenvy = "^0.15"
-envy = "^0.4"
-log = "^0.4"
-env_logger = "^0.11.10"
-chrono = { version = "^0.4.44", default-features = false, features = ["clock", "serde"] }
-regex = "^1.12.3"
-itertools = "^0.14"
-clap = { version = "^4.6.0", features = ["derive"] }
-tokio = { version = "^1.50.0", features = ["full"] }
-futures = "^0.3.32"
+anyhow = "1"
+graphql_client = "0.14"
+serde = "1"
+serde_json = "1"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+terminal_size = "0.4"
+comfy-table = "7"
+dotenvy = "0.15"
+envy = "0.4"
+log = "0.4"
+env_logger = "0.11"
+chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
+regex = "1"
+itertools = "0.14"
+clap = { version = "4", features = ["derive"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+futures = "0.3"
 


### PR DESCRIPTION
## Summary
- Optimized tokio features from  to  for faster compilation
- Bumped version to 1.0.12
- Removed caret version constraints (^X to X) for most dependencies
- Removed signal-hook-registry dependency