### PR TITLE
Update Rust edition from 2021 to 2024

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,6 +94,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "temp-env",
  "terminal_size",
  "tokio",
 ]
@@ -1636,6 +1637,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "temp-env"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
+dependencies = [
+ "parking_lot",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "The tool that helps optimize the code review process."
 documentation = "https://github.com/frisoft/ateam"
 repository = "https://github.com/frisoft/ateam"
 readme = "README.md"
-edition = "2021"
+edition = "2024"
 keywords = ["cli", "github", "code-review", "pull-request", "command-line"]
 
 [lints.clippy]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,3 +56,6 @@ clap = { version = "4", features = ["derive"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 futures = "0.3"
 
+[dev-dependencies]
+temp-env = "0.3"
+

--- a/src/client/blame.rs
+++ b/src/client/blame.rs
@@ -1,6 +1,6 @@
 use std::fmt::Write;
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use futures::stream::{FuturesUnordered, StreamExt};
 use graphql_client::{GraphQLQuery, Response};
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -2,7 +2,7 @@ use std::fmt::Write;
 
 use super::cli::PrArgs;
 use super::types::{Files, Label, Labels, Pr, ReviewRequested, Score, ScoredPr, TestsState};
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use chrono::prelude::{DateTime as DT, Utc};
 use graphql_client::{GraphQLQuery, QueryBody, Response};
 use itertools::Itertools;
@@ -201,11 +201,7 @@ fn github_query(username: &str, options: &PrArgs) -> String {
 }
 
 fn query_drafts(include_drafts: bool) -> &'static str {
-    if include_drafts {
-        ""
-    } else {
-        "draft:false "
-    }
+    if include_drafts { "" } else { "draft:false " }
 }
 
 fn query_mine(username: &str, only_mine: bool) -> String {

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,20 +18,20 @@ mod tests {
 
     #[test]
     fn test_config_deserialization() {
-        env::set_var("GITHUB_API_TOKEN", "test_token_abc123");
+        unsafe { env::set_var("GITHUB_API_TOKEN", "test_token_abc123") };
         let result: Result<Config, _> = envy::from_env();
         let config = result.expect("Failed to deserialize");
         assert_eq!(config.github_api_token, "test_token_abc123");
-        env::remove_var("GITHUB_API_TOKEN");
+        unsafe { env::remove_var("GITHUB_API_TOKEN") };
     }
 
     #[test]
     fn test_config_missing_token() {
         // First ensure any leftover token from other tests is removed
-        env::remove_var("GITHUB_API_TOKEN");
+        unsafe { env::remove_var("GITHUB_API_TOKEN") };
 
         // Also unset any dotenv override
-        std::env::remove_var("GITHUB_TOKEN");
+        unsafe { std::env::remove_var("GITHUB_TOKEN") };
 
         let result: Result<Config, _> = envy::from_env();
         // This test might be flaky if .env file exists in test environment

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,28 +14,28 @@ pub fn get_config() -> Result<Config, envy::Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::env;
 
     #[test]
     fn test_config_deserialization() {
-        unsafe { env::set_var("GITHUB_API_TOKEN", "test_token_abc123") };
-        let result: Result<Config, _> = envy::from_env();
-        let config = result.expect("Failed to deserialize");
-        assert_eq!(config.github_api_token, "test_token_abc123");
-        unsafe { env::remove_var("GITHUB_API_TOKEN") };
+        temp_env::with_var("GITHUB_API_TOKEN", Some("test_token_abc123"), || {
+            let result: Result<Config, _> = envy::from_env();
+            let config = result.expect("Failed to deserialize");
+            assert_eq!(config.github_api_token, "test_token_abc123");
+        });
     }
 
     #[test]
     fn test_config_missing_token() {
-        // First ensure any leftover token from other tests is removed
-        unsafe { env::remove_var("GITHUB_API_TOKEN") };
-
-        // Also unset any dotenv override
-        unsafe { std::env::remove_var("GITHUB_TOKEN") };
-
-        let result: Result<Config, _> = envy::from_env();
-        // This test might be flaky if .env file exists in test environment
-        // Just verify it doesn't panic
-        let _ = result;
+        // Unset both GITHUB_API_TOKEN and any dotenv override (GITHUB_TOKEN)
+        temp_env::with_vars(
+            [
+                ("GITHUB_API_TOKEN", None::<&str>),
+                ("GITHUB_TOKEN", None::<&str>),
+            ],
+            || {
+                let result: Result<Config, _> = envy::from_env();
+                let _ = result; // Just verify it doesn't panic
+            },
+        );
     }
 }

--- a/src/table.rs
+++ b/src/table.rs
@@ -2,7 +2,7 @@ use super::types::{Files, Review, ScoredPr, TestsState};
 use comfy_table::modifiers::UTF8_ROUND_CORNERS;
 use comfy_table::presets::UTF8_FULL;
 use comfy_table::{ColumnConstraint, ContentArrangement, Table};
-use terminal_size::{terminal_size, Height, Width};
+use terminal_size::{Height, Width, terminal_size};
 
 #[cfg(test)]
 use super::types::{Labels, Pr, ReviewState, Score};
@@ -79,11 +79,7 @@ fn pr_row(spr: &ScoredPr, debug: bool) -> Vec<String> {
 const YES: &str = "yes";
 const NO: &str = "no";
 fn show_bool(value: bool) -> &'static str {
-    if value {
-        YES
-    } else {
-        NO
-    }
+    if value { YES } else { NO }
 }
 
 fn tests_result_label(tests_result: &TestsState) -> &'static str {


### PR DESCRIPTION
Bump the Rust edition to 2024 (latest stable edition available since Rust 1.85).

Changes:
- `Cargo.toml`: edition set to `"2024"`
- `src/client/blame.rs`, `src/client/mod.rs`, `src/table.rs`: reformatted by `cargo fmt` (import ordering changes due to edition 2024 rules)
- `src/config.rs`: replaced `env::set_var`/`env::remove_var` (now `unsafe` in 2024 edition) with `temp_env::with_var`/`with_vars` for safe, panic-proof env var handling in tests
- `Cargo.toml`: added `temp-env` dev-dependency